### PR TITLE
chore: run CodeQL weekly only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,11 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # Run weekly only (Wednesday at 3:17 AM UTC) - analysis is slow
   schedule:
     - cron: '17 3 * * 3'
+  # Allow manual trigger
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ release_notes.md
 
 # My local notes to myself
 build notes.txt
+apple-dev-distribution-guide.md


### PR DESCRIPTION
## Summary
- CodeQL now runs weekly instead of on every push/PR (analysis is slow)
- Added manual trigger option (`workflow_dispatch`)
- Added `apple-dev-distribution-guide.md` to gitignore

## Test plan
- [x] CodeQL will run on Wednesdays at 3:17 AM UTC
- [x] Can be manually triggered from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)