### PR TITLE
docs: refresh README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Screenshot Renamer
 
-[![CI/CD](https://github.com/tpak/ScreenshotRenamer/actions/workflows/swift.yml/badge.svg?branch=main)](https://github.com/tpak/ScreenshotRenamer/actions/workflows/swift.yml)
+[![CI/CD](https://img.shields.io/github/actions/workflow/status/tpak/ScreenshotRenamer/swift.yml?branch=main&label=CI%2FCD)](https://github.com/tpak/ScreenshotRenamer/actions/workflows/swift.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/tpak/ScreenshotRenamer/codeql.yml?branch=main&label=CodeQL)](https://github.com/tpak/ScreenshotRenamer/actions/workflows/codeql.yml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/tpak/ScreenshotRenamer)](https://github.com/tpak/ScreenshotRenamer/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform](https://img.shields.io/badge/Platform-macOS%2011.0%2B-blue.svg)](https://www.apple.com/macos/)
 
 Native macOS menu bar app that automatically renames screenshots from 12-hour to 24-hour format so they sort chronologically in Finder.
 


### PR DESCRIPTION
## Summary
- Add CodeQL workflow status badge
- Switch CI badge to shields.io so the label actually renders as **CI/CD** (the native GitHub badge always shows the workflow name "Swift CI")
- Remove License badge — duplicative with GitHub's sidebar license detection
- Remove Platform badge — the macOS 11.0 floor is unverified

README-only change; no version bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)